### PR TITLE
feat: dynamic versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The next generation of documentation for HStreamDB.
   - [\_index.md](#_indexmd)
   - [list.json](#listjson)
   - [About sidebar](#about-sidebar)
+  - [Special markdown syntaxes](#special-markdown-syntaxes)
 - [Release a new version](#release-a-new-version)
 
 ## Development
@@ -93,6 +94,26 @@ The sidebar is generated base on the file structure of the `docs` folder automat
 - Files in `docs/zh/v*` will be generated as the zh v\* sidebar.
 
 Even though the rules are a little complicated, you don't need to worry about it. [Once a version is released](#release-a-new-version), the sidebar will be generated automatically.
+
+### Special markdown syntaxes
+
+#### {{ $version() }}
+
+`{{ $version() }}` is a special syntax that is used to display the current version of the docs. It will be replaced with the current version when the docs are built. For example:
+
+> It's important to keep in mind that when using vue-style interpolation in code blocks, you should add a suffix of `-vue` to the language, such as `shell-vue`.
+
+Input:
+
+```sh
+docker pull hstreamdb/hstream:{{ $version() }}
+```
+
+Output:
+
+```sh
+docker pull hstreamdb/hstream:v0.15.0
+```
 
 ## Release a new version
 

--- a/assets/quick-start.yaml
+++ b/assets/quick-start.yaml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   hserver:
-    image: hstreamdb/hstream:latest
+    image: hstreamdb/hstream:{{ $version() }}
     depends_on:
       - zookeeper
       - hstore
@@ -36,7 +36,7 @@ services:
         --io-tasks-network hstream-quickstart
 
   hstore:
-    image: hstreamdb/hstream:latest
+    image: hstreamdb/hstream:{{ $version() }}
     networks:
       - hstream-quickstart
     volumes:

--- a/docs/.vitepress/theme/index.js
+++ b/docs/.vitepress/theme/index.js
@@ -2,6 +2,7 @@ import DefaultTheme from 'vitepress/theme'
 import { h } from 'vue'
 import GitPod from './GitPod.vue'
 import './custom.css'
+import { usePickVersion } from './pickVersion'
 
 export default {
   ...DefaultTheme,
@@ -9,5 +10,8 @@ export default {
     return h(DefaultTheme.Layout, null, {
       'aside-top': () => h(GitPod),
     })
+  },
+  enhanceApp({ app }) {
+    app.config.globalProperties.$version = usePickVersion
   },
 }

--- a/docs/.vitepress/theme/pickVersion.js
+++ b/docs/.vitepress/theme/pickVersion.js
@@ -1,0 +1,13 @@
+import { useData } from 'vitepress'
+
+export function usePickVersion() {
+  const { page } = useData()
+
+  const matched = page.value.filePath.match(/v\d+\.\d+\.\d+/)
+
+  if (matched) {
+    return matched[0]
+  } else {
+    return 'latest'
+  }
+}

--- a/docs/deploy/deploy-docker.md
+++ b/docs/deploy/deploy-docker.md
@@ -160,9 +160,9 @@ For the configuration file stored on each node, assume that your file path is
 
 - Configuration file stored in ZooKeeper：
 
-  ```shell
+  ```shell-vue
   docker run --rm -d --name storeAdmin --network host -v /data/logdevice:/data/logdevice \
-          hstreamdb/hstream:latest /usr/local/bin/ld-admin-server \
+          hstreamdb/hstream:{{ $version() }} /usr/local/bin/ld-admin-server \
           --config-path zk:10.100.2.11:2181/logdevice.conf \
           --enable-maintenance-manager \
           --maintenance-log-snapshotting \
@@ -182,9 +182,9 @@ For the configuration file stored on each node, assume that your file path is
 
 - Configuration file stored in ZooKeeper：
 
-  ```shell
+  ```shell-vue
   docker run --rm -d --name hstore --network host -v /data/logdevice:/data/logdevice \
-          hstreamdb/hstream:latest /usr/local/bin/logdeviced \
+          hstreamdb/hstream:{{ $version() }} /usr/local/bin/logdeviced \
           --config-path zk:10.100.2.11:2181/logdevice.conf \
           --name store-0 \
           --address 192.168.0.3 \
@@ -243,9 +243,9 @@ Now we finish setting up the `HStore` cluster.
 To start a single `HServer` instance, you can modify the start command to fit
 your situation:
 
-```shell
+```shell-vue
 docker run -d --name hstream-server --network host \
-        hstreamdb/hstream:latest /usr/local/bin/hstream-server \
+        hstreamdb/hstream:{{ $version() }} /usr/local/bin/hstream-server \
         --bind-address $SERVER_HOST \
         --advertised-address $SERVER_HOST \
         --seed-nodes $SERVER_HOST \

--- a/docs/deploy/deploy-k8s.md
+++ b/docs/deploy/deploy-k8s.md
@@ -155,8 +155,8 @@ zookeeper-2                                          1/1     Running   0        
 Once all the logdevice pods are running and ready, you'll need to bootstrap the
 cluster to enable all the nodes. To do that, run:
 
-```sh
-kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:latest -- \
+```sh-vue
+kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:{{ $version() }} -- \
   hadmin store --host logdevice-admin-server-service \
     nodes-config bootstrap --metadata-replicate-across 'node:3'
 ```
@@ -166,21 +166,21 @@ invokes the `nodes-config bootstrap` hadmin store command and sets the metadata
 replication property of the cluster to be replicated across three different
 nodes. On success, you should see something like:
 
-```
+```txt
 Successfully bootstrapped the cluster
 pod "hstream-admin" deleted
 ```
 
 Now, you can boostrap hstream server, by running the following command:
 
-```sh
-kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:latest -- \
+```sh-vue
+kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:{{ $version() }} -- \
     hadmin server --host hstream-server-0.hstream-server init
 ```
 
 On success, you should see something like:
 
-```
+```txt
 Cluster is ready!
 pod "hstream-admin" deleted
 ```
@@ -190,13 +190,13 @@ Note that depending on how fast the storage cluster completes bootstrap, running
 
 ## Managing the Storage Cluster
 
-```sh
-kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:latest -- bash
+```sh-vue
+kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:{{ $version() }} -- bash
 ```
 
 Now you can run `hadmin store` to manage the cluster:
 
-```
+```sh
 hadmin store --help
 ```
 
@@ -206,7 +206,7 @@ To check the state of the cluster, you can then run:
 hadmin store --host logdevice-admin-server-service status
 ```
 
-```
+```txt
 +----+-------------+-------+---------------+
 | ID |    NAME     | STATE | HEALTH STATUS |
 +----+-------------+-------+---------------+

--- a/docs/ingest-and-distribute/user_guides.md
+++ b/docs/ingest-and-distribute/user_guides.md
@@ -102,8 +102,8 @@ SQLs to create connectors.
 
 Connect to the HStream server:
 
-```shell
-docker run -it --rm --network host hstreamdb/hstream:latest hstream sql --port 6570
+```shell-vue
+docker run -it --rm --network host hstreamdb/hstream:{{ $version() }} hstream sql --port 6570
 ```
 
 Create a source connector:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,8 +2,8 @@
 
 We can run the following to use HStream CLI:
 
-```sh
-docker run -it --rm --name some-hstream-admin --network host hstreamdb/hstream:latest hstream --help
+```sh-vue
+docker run -it --rm --name some-hstream-admin --network host hstreamdb/hstream:{{ $version() }} hstream --help
 ```
 
 For ease of illustration, we execute an interactive bash shell in the HStream
@@ -18,7 +18,7 @@ docker exec -it docker_hserver_1 bash
 > hstream --help
 ```
 
-```
+```txt
 ======= HStream CLI =======
 
 Usage: hstream [--host SERVER-HOST] [--port INT] [--tls-ca STRING]

--- a/docs/start/quickstart-with-docker.md
+++ b/docs/start/quickstart-with-docker.md
@@ -57,7 +57,7 @@ Do NOT use this configuration in your production environment!
 Create a docker-compose.yaml file for docker compose, you can
 [download][quick-start.yaml] or paste the following contents:
 
-```yaml
+```yaml-vue
 # quick-start.yaml
 ```
 
@@ -91,8 +91,8 @@ docker-compose -f quick-start.yaml logs -f hserver
 
 ## Start HStreamDB's interactive SQL CLI
 
-```sh
-docker run -it --rm --name some-hstream-cli --network host hstreamdb/hstream:latest hstream --port 6570 sql
+```sh-vue
+docker run -it --rm --name some-hstream-cli --network host hstreamdb/hstream:{{ $version() }} hstream --port 6570 sql
 ```
 
 If everything works fine, you will enter an interactive CLI and see help

--- a/docs/zh/deploy/deploy-docker.md
+++ b/docs/zh/deploy/deploy-docker.md
@@ -146,7 +146,7 @@ docker exec zookeeper zkCli.sh get /logdevice.conf
 
 ## 配置 HStore 集群
 
-对于存储在 ZooKeeper 中的配置文件，假设配置文件中 `zookeeper_uri` 字段的值是 `"ip:/10.100.2.11:2181"` ，ZooKeeper中配置文件的路径是 `/logdevice.conf` 。
+对于存储在 ZooKeeper 中的配置文件，假设配置文件中 `zookeeper_uri` 字段的值是 `"ip:/10.100.2.11:2181"` ，ZooKeeper 中配置文件的路径是 `/logdevice.conf` 。
 
 对于存储在每个节点上的配置文件，假设你的文件路径是 `/data/logdevice/logdevice.conf'。
 
@@ -154,16 +154,16 @@ docker exec zookeeper zkCli.sh get /logdevice.conf
 
 - 配置文件存储在 ZooKeeper 中：
 
-  ```shell
+  ```shell-vue
   docker run --rm -d --name storeAdmin --network host -v /data/logdevice:/data/logdevice \
-          hstreamdb/hstream:latest /usr/local/bin/ld-admin-server \
+          hstreamdb/hstream:{{ $version() }} /usr/local/bin/ld-admin-server \
           --config-path zk:10.100.2.11:2181/logdevice.conf \
           --enable-maintenance-manager \
           --maintenance-log-snapshotting \
           --enable-safety-check-periodic-metadata-update
   ```
 
-  + 如果你有一个多节点的 ZooKeeper，请将`--config-path`替换为：
+  - 如果你有一个多节点的 ZooKeeper，请将`--config-path`替换为：
     `--config-path zk:10.100.2.11:2181,10.100.2.12:2181,10.100.2.13:2181/logdevice.conf`
 
 - 存储在每个节点的配置文件：
@@ -174,16 +174,16 @@ docker exec zookeeper zkCli.sh get /logdevice.conf
 
 - 存储在 ZooKeeper 中的配置文件：
 
-  ```shell
+  ```shell-vue
   docker run --rm -d --name hstore --network host -v /data/logdevice:/data/logdevice \
-          hstreamdb/hstream:latest /usr/local/bin/logdeviced \
+          hstreamdb/hstream:{{ $version() }} /usr/local/bin/logdeviced \
           --config-path zk:10.100.2.11:2181/logdevice.conf \
           --name store-0 \
           --address 192.168.0.3 \
           --local-log-store-path /data/logdevice
   ```
 
-  + 对于每个节点，你应该将`--name`更新为一个不同的值，并将`--address`更新为该节点的 IP 地址。
+  - 对于每个节点，你应该将`--name`更新为一个不同的值，并将`--address`更新为该节点的 IP 地址。
 
 - 存储在每个节点的配置文件：
 
@@ -231,9 +231,9 @@ Took 7.745s
 
 要启动一个单一的 `HServer` 实例，你可以修改启动命令以适应你的情况。
 
-```shell
+```shell-vue
 docker run -d --name hstream-server --network host \
-        hstreamdb/hstream:latest /usr/local/bin/hstream-server \
+        hstreamdb/hstream:{{ $version() }} /usr/local/bin/hstream-server \
         --bind-address $SERVER_HOST \
         --advertised-address $SERVER_HOST \
         --seed-nodes $SERVER_HOST \

--- a/docs/zh/deploy/deploy-k8s.md
+++ b/docs/zh/deploy/deploy-k8s.md
@@ -149,8 +149,8 @@ zookeeper-2                                          1/1     Running   0        
 一旦所有的 logdevice pods 运行并准备就绪，你将需要 Bootstrap 集群以启用所有的存
 储节点。要做到这一点，请运行：
 
-```sh
-kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:latest -- \
+```sh-vue
+kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:{{ $version() }} -- \
     hadmin store --host logdevice-admin-server-service \
     nodes-config \
     bootstrap --metadata-replicate-across 'node:3'
@@ -162,21 +162,21 @@ kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:lat
 
 成功后，你应该看到类似如下：
 
-```
+```txt
 Successfully bootstrapped the cluster
 pod "hstream-admin" deleted
 ```
 
 现在，你可以 bootstrap server 节点：
 
-```sh
-kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:latest -- \
+```sh-vue
+kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:{{ $version() }} -- \
     hadmin server --host hstream-server-0.hstream-server init
 ```
 
 成功后，你应该看到类似如下：
 
-```
+```txt
 Cluster is ready!
 pod "hstream-admin" deleted
 ```
@@ -186,13 +186,13 @@ pod "hstream-admin" deleted
 
 ## 管理存储集群
 
-```sh
-kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:latest -- bash
+```sh-vue
+kubectl run hstream-admin -it --rm --restart=Never --image=hstreamdb/hstream:{{ $version() }} -- bash
 ```
 
 现在你可以运行 `hadmin store` 来管理这个集群：
 
-```
+```sh
 hadmin store --help
 ```
 
@@ -202,7 +202,7 @@ hadmin store --help
 hadmin store --host logdevice-admin-server-service status
 ```
 
-```
+```txt
 +----+-------------+-------+---------------+
 | ID |    NAME     | STATE | HEALTH STATUS |
 +----+-------------+-------+---------------+

--- a/docs/zh/ingest-and-distribute/user_guides.md
+++ b/docs/zh/ingest-and-distribute/user_guides.md
@@ -102,8 +102,8 @@ SQLs to create connectors.
 
 Connect to the HStream server:
 
-```shell
-docker run -it --rm --network host hstreamdb/hstream:latest hstream sql --port 6570
+```shell-vue
+docker run -it --rm --network host hstreamdb/hstream:{{ $version() }} hstream sql --port 6570
 ```
 
 Create a source connector:

--- a/docs/zh/reference/cli.md
+++ b/docs/zh/reference/cli.md
@@ -2,8 +2,8 @@
 
 We can run the following to use HStream CLI:
 
-```sh
-docker run -it --rm --name some-hstream-admin --network host hstreamdb/hstream:latest hstream --help
+```sh-vue
+docker run -it --rm --name some-hstream-admin --network host hstreamdb/hstream:{{ $version() }} hstream --help
 ```
 
 For ease of illustration, we execute an interactive bash shell in the HStream
@@ -18,7 +18,7 @@ docker exec -it docker_hserver_1 bash
 > hstream --help
 ```
 
-```
+```txt
 ======= HStream CLI =======
 
 Usage: hstream [--host SERVER-HOST] [--port INT] [--tls-ca STRING]

--- a/docs/zh/start/quickstart-with-docker.md
+++ b/docs/zh/start/quickstart-with-docker.md
@@ -52,7 +52,7 @@ docker-compose -v
 
 创建一个 quick-start.yaml, 可以直接[下载][quick-start.yaml]或者复制以下内容:
 
-```yaml
+```yaml-vue
 # quick-start.yaml
 ```
 
@@ -64,7 +64,7 @@ docker-compose -f quick-start.yaml up
 
 如果出现如下信息，表明现在已经有了一个运行中的 HServer：
 
-```
+```txt
 hserver_1    | [INFO][2021-11-22T09:15:18+0000][app/server.hs:137:3][thread#67]************************
 hserver_1    | [INFO][2021-11-22T09:15:18+0000][app/server.hs:145:3][thread#67]Server started on port 6570
 hserver_1    | [INFO][2021-11-22T09:15:18+0000][app/server.hs:146:3][thread#67]*************************
@@ -80,19 +80,19 @@ docker-compose -f quick-start.yaml up -d
 
 并且可以通过以下命令展示 logs ：
 
-```
+```sh
 docker-compose -f quick-start.yaml logs -f hserver
 ```
 
 ## 启动 HStreamDB 的 SQL 命令行界面
 
-```sh
-docker run -it --rm --name some-hstream-cli --network host hstreamdb/hstream:latest hstream --port 6570 sql
+```sh-vue
+docker run -it --rm --name some-hstream-cli --network host hstreamdb/hstream:{{ $version() }} hstream --port 6570 sql
 ```
 
 如果所有的步骤都正确运行，您将会进入到命令行界面，并且能看见一下帮助信息：
 
-```
+```txt
       __  _________________  _________    __  ___
      / / / / ___/_  __/ __ \/ ____/   |  /  |/  /
     / /_/ /\__ \ / / / /_/ / __/ / /| | / /|_/ /
@@ -170,7 +170,5 @@ INSERT INTO demo (temperature, humidity) VALUES (28, 86);
 {"temperature":28,"humidity":86}
 ```
 
-[non-root-docker]:
-  https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user
-[quick-start.yaml]:
-  https://raw.githubusercontent.com/hstreamdb/docs/main/assets/quick-start.yaml
+[non-root-docker]: https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user
+[quick-start.yaml]: https://raw.githubusercontent.com/hstreamdb/docs/main/assets/quick-start.yaml


### PR DESCRIPTION
This pull request introduces the ability to include dynamic versions in markdown files. An example of this is shown below:

> It's important to keep in mind that when using vue-style interpolation in code blocks, you should add a suffix of `-vue` to the language, such as `shell-vue`.

### Input

```
docker pull hstreamdb/hstream:{{ $version() }}
```

### Output

```
docker pull hstreamdb/hstream:v0.15.0
```
