### PR TITLE
chore: duplicate platform docs into /zh

### DIFF
--- a/docs/start/try-out-hstream-platform.md
+++ b/docs/start/try-out-hstream-platform.md
@@ -16,7 +16,7 @@ If you already have an account, you can skip this step.
 By creating an account, you agree to the [Terms of Service](https://www.emqx.com/en/policy/terms-of-use) and [Privacy Policy](https://www.emqx.com/en/policy/privacy-policy).
 :::
 
-To create a new account, please fill in the required information on the form provided on the [Sign Up](https://platform.hstream.io/app/signup) page, all fields are shown below:
+To create a new account, please fill in the required information on the form provided on the [Sign Up](https://platform.hstream.io/console/signup) page, all fields are shown below:
 
 - **Username**: Your username.
 - **Email**: Your email address. This email address will be used for the HStream Platform login.
@@ -27,7 +27,7 @@ After completing the necessary fields, click the **Sign Up** button to proceed w
 
 ### Log in to the HStream Platform
 
-To log in to the HStream Platform after creating an account, please fill in the required information on the form provided on the [Log In](https://platform.hstream.io/app/login) page, all fields are shown below:
+To log in to the HStream Platform after creating an account, please fill in the required information on the form provided on the [Log In](https://platform.hstream.io/console/login) page, all fields are shown below:
 
 - **Email**: Your email address.
 - **Password**: Your password.

--- a/docs/zh/_index.md
+++ b/docs/zh/_index.md
@@ -3,6 +3,7 @@ order:
   [
     'overview',
     'start',
+    'platform',
     'write',
     'receive',
     'process',

--- a/docs/zh/platform/_index.md
+++ b/docs/zh/platform/_index.md
@@ -1,0 +1,12 @@
+---
+order:
+  - stream-in-platform.md
+  - write-in-platform.md
+  - subscription-in-platform.md
+  - create-queries-in-platform.md
+  - create-views-in-platform.md
+  - create-connectors-in-platform.md
+collapsed: false
+---
+
+HStream Platform

--- a/docs/zh/platform/create-connectors-in-platform.md
+++ b/docs/zh/platform/create-connectors-in-platform.md
@@ -1,0 +1,108 @@
+# 创建和管理 Connector
+
+This page describes how to create and manage connectors in HStream Platform.
+
+## Create a connector
+
+Connector has two types: source connector and sink connector. The source connector is used to ingest data from external systems into HStream Platform, while the sink connector is used to distribute data from HStream Platform to external systems.
+
+### Create a source connector
+
+First, navigate to the **Sources** page and click the **New source** button to go to the **Create a new source** page.
+
+In this page, you should first select the **Connector type**. Currently, HStream Platform supports the following source connectors:
+
+- MongoDB
+- MySQL
+- PostgreSQL
+- SQL Server
+- Generator
+
+Click one of them to select it, and then the page will display the corresponding configuration form.
+
+After filling in the configuration, click the **Create** button to create the source connector.
+
+::: tip
+
+For more details about the configuration of each source connector, please refer to [Connectors](../ingest-and-distribute/connectors.md).
+
+:::
+
+### Create a sink connector
+
+Create a sink connector is similar to create a source connector. First, navigate to the **Sinks** page and click the **New sink** button to go to the **Create a new sink** page.
+
+Then the next steps are the same as creating a source connector.
+
+Currently, HStream Platform supports the following sink connectors:
+
+- MongoDB
+- MySQL
+- PostgreSQL
+- Blackhole
+
+## View connectors
+
+The **Sources** and **Sinks** pages display all the connectors in your account. For each connector, you can view the following information:
+
+- The **Name** of the connector.
+- The **Created time** of the connector.
+- The **Status** of the connector.
+- The **Type** of the connector.
+- **Actions**, which for the extra operations of the connector:
+
+  - **Duplicate**: Duplicate the connector.
+  - **Delete**: Delete the connector.
+
+To view a specific connector, you can click the **Name** of the connector to go to the [details page](#view-connector-details).
+
+## View connector details
+
+The details page displays the detailed information of a connector:
+
+1. All the information in the [connectors](#view-connectors) page.
+2. Different tabs are provided to display the related information of the connector:
+
+   - [**Overview**](#view-connector-overview): Besides the basic information, also can view the metrics of the connector.
+   - **Config**: View the configuration of the connector.
+   - [**Consumption Process**](#view-connector-consumption-process): View the consumption process of the connector.
+   - **Logs**: View the tasks of the connector.
+
+## View connector overview
+
+The **Overview** page displays the metrics of a connector. The default duration is **last 5 minutes**. You can select different durations to control the time range of the metrics:
+
+- last 5 minutes
+- last 1 hour
+- last 3 hours
+- last 6 hours
+- last 12 hours
+- last 1 day
+- last 3 days
+- last 1 week
+
+The metrics of the connector include (with last 5 minutes as an example), from left to right:
+
+- **Processed records throughput**: The number of records that the connector processes per second.
+- **Processed bytes throughput**: The number of bytes that the connector processes per second.
+- **Total records** (Sink): The number of records that the connector processes in the last 5 minutes.
+
+## View connector consumption process
+
+The **Consumption Process** page displays the consumption process of a connector. Different connectors have different consumption processes.
+
+## Delete a connector
+
+This section describes how to delete a connector.
+
+### Delete a connector from the Connectors page
+
+1. Navigate to the **Connectors** page.
+2. Click the **Delete** icon of the connector you want to delete. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.
+
+### Delete a connector from the Connector Details page
+
+1. Navigate to the details page of the connector you want to delete.
+2. Click the **Delete** button. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.

--- a/docs/zh/platform/create-queries-in-platform.md
+++ b/docs/zh/platform/create-queries-in-platform.md
@@ -1,0 +1,127 @@
+# 创建和管理 Streaming Query
+
+This page describes how to create and manage streaming queries in HStream Platform.
+
+## Create a query
+
+First, navigate to the **Queries** page and click the **Create query** button to
+go to the **Create query** page.
+
+In this page, you can see 3 areas used throughout the creation process:
+
+- The **Stream Catalog** area on the left is used to select the streams you
+  want to use in the query.
+- The **Query Editor** area on the top right is used to write the query.
+- The **Query Result** area on the bottom right is used to display the query result.
+
+Below sections describe how these areas are used in the creation process.
+
+### Stream Catalog
+
+The **Stream Catalog** will display all the streams as a list. You can use one of
+them as the source stream of the query. For example, if a stream is `test`, after
+selecting it, the **Query Editor** will be filled with the following query:
+
+```sql
+CREATE STREAM stream_iyngve AS SELECT * FROM test;
+```
+
+This can help you quickly create a query. You can also change the query to meet your needs.
+
+::: tip
+The auto-generated query is commented by default. You need to uncomment it to make it work.
+:::
+
+::: info
+The auto-generated query will generate a stream with a `stream_` prefix and a random suffix after
+creating it. You can change the name of the stream to meet your needs.
+:::
+
+### Query Editor
+
+The **Query Editor** is used to write the query.
+
+Besides the textarea, there are still a right sidebar to assist you in writing the query.
+To create a query, you need to provide a **Query name** to identify the query, an text field in the right sidebar will automatically generate a query name for you. You can also change it to meet your needs.
+
+Once you finish writing the query, click the **Save & Run** button to create the query and run it.
+
+### Query Result
+
+After creating the query, the **Query Result** area will display the query result in real time.
+
+The query result is displayed in a table. Each row represents a record in the stream. You can refer to [Get Records](./write-in-platform.md#get-records) to learn more about the record.
+
+If you want to stop viewing the query result, you can click the **Cancel** button to stop it. For re-viewing the query result, you can click the **View Live Result** button to view again.
+
+::: info
+
+When creating a materialized view, it will internally create a query and its result is the view. So the query result is the same as the view result.
+
+:::
+
+## View queries
+
+The **Queries** page displays all the queries in your account. For each query, you can view the following information:
+
+- The **Name** of the query.
+- The **Created time** of the query.
+- The **Status** of the query.
+- The **SQL** of the query.
+- **Actions**, which for the extra operations of the query:
+
+  - **Terminate**: Terminate the query.
+  - **Duplicate**: Duplicate the query.
+  - **Delete**: Delete the query.
+
+To view a specific query, you can click the **Name** of the query to go to the [details page](#view-query-details).
+
+## View query details
+
+The details page displays the detailed information of a query:
+
+1. All the information in the [queries](#view-queries) page.
+2. Different tabs are provided to display the related information of the query:
+
+   - [**Overview**](#view-query-overview): Besides the basic information, also can view the metrics of the query.
+   - [**SQL**](#view-query-sql): View the SQL of the query.
+
+## View query overview
+
+The **Overview** page displays the metrics of a query. The default duration is **last 5 minutes**. You can select different durations to control the time range of the metrics:
+
+- last 5 minutes
+- last 1 hour
+- last 3 hours
+- last 6 hours
+- last 12 hours
+- last 1 day
+- last 3 days
+- last 1 week
+
+The metrics of the query include (with last 5 minutes as an example), from left to right:
+
+- **Input records throughput**: The number of records that the query receives from the source stream per second.
+- **Output records throughput**: The number of records that the query outputs to the result stream per second.
+- **Total records**: The number of records to the query in the last 5 minutes. Including input and output records.
+- **Execution errors**: The number of errors that the query encounters in the last 5 minutes.
+
+## View query SQL
+
+The **SQL** page displays the SQL of a query. You can only view the SQL of the query, but cannot edit it.
+
+## Delete a query
+
+This section describes how to delete a query.
+
+### Delete a query from the Queries page
+
+1. Navigate to the **Queries** page.
+2. Click the **Delete** icon of the query you want to delete. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.
+
+### Delete a query from the Query Details page
+
+1. Navigate to the details page of the query you want to delete.
+2. Click the **Delete** button. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.

--- a/docs/zh/platform/create-views-in-platform.md
+++ b/docs/zh/platform/create-views-in-platform.md
@@ -1,0 +1,70 @@
+# 创建和管理 Materialized View
+
+This page describes how to create and manage materialized views in HStream Platform.
+
+## Create a view
+
+Create a view is similar to create a query. The main difference is that the SQL is a `CREATE VIEW` statement.
+
+Please refer to [Create a query](./create-queries-in-platform.md#create-a-query) for more details.
+
+## View views
+
+The **Views** page displays all the views in your account. For each view, you can view the following information:
+
+- The **Name** of the view.
+- The **Created time** of the view.
+- The **Status** of the view.
+- **Actions**, which for the extra operations of the view:
+
+  - **Delete**: Delete the view.
+
+To view a specific view, you can click the **Name** of the view to go to the [details page](#view-view-details).
+
+## View view details
+
+The details page displays the detailed information of a view:
+
+1. All the information in the [views](#view-views) page.
+2. Different tabs are provided to display the related information of the view:
+
+   - [**Overview**](#view-view-overview): Besides the basic information, also can view the metrics of the view.
+   - [**SQL**](#view-view-sql): View the SQL of the view.
+
+## View view overview
+
+The **Overview** page displays the metrics of a view. The default duration is **last 5 minutes**. You can select different durations to control the time range of the metrics:
+
+- last 5 minutes
+- last 1 hour
+- last 3 hours
+- last 6 hours
+- last 12 hours
+- last 1 day
+- last 3 days
+- last 1 week
+
+The metrics of the view include (with last 5 minutes as an example), from left to right:
+
+- **Execution queries throughput**: The number of queries that the view executes per second.
+- **Execution queries**: The number of queries that the view executes in the last 5 minutes.
+
+## View view SQL
+
+The **SQL** page displays the SQL of a view. You can only view the SQL of the view, but cannot edit it.
+
+## Delete a view
+
+This section describes how to delete a view.
+
+### Delete a view from the Views page
+
+1. Navigate to the **Views** page.
+2. Click the **Delete** icon of the view you want to delete. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.
+
+### Delete a view from the View Details page
+
+1. Navigate to the details page of the view you want to delete.
+2. Click the **Delete** button. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.

--- a/docs/zh/platform/stream-in-platform.md
+++ b/docs/zh/platform/stream-in-platform.md
@@ -14,7 +14,7 @@ This tutorial guides you on how to create and manage streams in HStream Platform
 
 After clicking the **New stream** button, you will be directed to the **New Stream** page. You need to set some necessary properties for your stream and create it:
 
-1. Specify the **stream name**. You can refer to [Guidelines to name a resource](../write/stream.md#guidelines-to-name-a-resource) to name a stream.
+1. Specify the **stream name**. You can refer to [Guidelines to name a resource](../write/stream.md#命名资源准则) to name a stream.
 
 2. Fill in with the number of **shards** you want this stream to have. The default value is **1**.
 
@@ -27,7 +27,7 @@ After clicking the **New stream** button, you will be directed to the **New Stre
 5. Click the **Confirm** button to create a stream.
 
 ::: tip
-For more details about **replicas** and **retention**, please refer to [Attributes of a Stream](../write/stream.md#attributes-of-a-stream).
+For more details about **replicas** and **retention**, please refer to [Attributes of a Stream](../write/stream.md#stream-的属性).
 :::
 
 ::: warning

--- a/docs/zh/platform/stream-in-platform.md
+++ b/docs/zh/platform/stream-in-platform.md
@@ -1,0 +1,156 @@
+# 创建和管理 Stream
+
+This tutorial guides you on how to create and manage streams in HStream Platform.
+
+## Preparation
+
+1. If you do not have an account, please [apply for a trial](../start/try-out-hstream-platform.md#apply-for-a-trial) first and log in. After logging in, click **Streams** on the left sidebar to enter the streams page.
+
+2. If you have already logged in, click **Streams** on the left sidebar to enter the **Streams** page.
+
+3. Click the **New stream** button to create a stream.
+
+## Create a stream
+
+After clicking the **New stream** button, you will be directed to the **New Stream** page. You need to set some necessary properties for your stream and create it:
+
+1. Specify the **stream name**. You can refer to [Guidelines to name a resource](../write/stream.md#guidelines-to-name-a-resource) to name a stream.
+
+2. Fill in with the number of **shards** you want this stream to have. The default value is **1**.
+
+   > Shard is the primary storage unit for the stream. For more details, please refer to [Sharding in HStreamDB](../write/shards.md#sharding-in-hstreamdb).
+
+3. Fill in with the number of **replicas** for each stream. The default value is **3**.
+
+4. Fill in with the number of **retention** for each stream. Default value is **72**. Unit is **hour**.
+
+5. Click the **Confirm** button to create a stream.
+
+::: tip
+For more details about **replicas** and **retention**, please refer to [Attributes of a Stream](../write/stream.md#attributes-of-a-stream).
+:::
+
+::: warning
+Currently, the number of **replicas** and **retention** are fixed for each stream in HStream Platform. We will gradually adjust these attributes in the future.
+:::
+
+## View streams
+
+The **Streams** page lists all the streams in your account with a high-level overview. For each stream, you can view the following information:
+
+- The **name** of the stream.
+- The **Creation time** of the stream.
+- The number of **shards** in a stream.
+- The number of **replicas** in a stream.
+- The **Data retention period** of the records in a stream.
+- **Actions**, which for the extra operations of the stream:
+
+  - **Metrics**: View the metrics of the stream.
+  - **Subscriptions**: View the subscriptions of the stream.
+  - **Shards**: View the shard details of the stream.
+  - **Delete**: Delete the stream.
+
+To view a specific stream, click the name. [The details page of the stream](#view-stream-details) will be displayed.
+
+## View stream details
+
+The details page displays the detailed information of a stream:
+
+1. All the information in the [streams](#view-streams) page.
+2. Different tabs are provided to display the related information of the stream:
+
+   - [**Metrics**](#view-stream-metrics): View the metrics of the stream.
+   - [**Subscriptions**](#view-stream-subscriptions): View the subscriptions of the stream.
+   - [**Shards**](#view-stream-shards): View the shard details of the stream.
+   - [**Records**](#get-records-in-a-stream): Search records in the stream.
+
+### View stream metrics
+
+After clicking the **Metrics** tab, you can view the metrics of the stream.
+The default duration is **last 5 minutes**. You can select different durations to control the time range of the metrics:
+
+- last 5 minutes
+- last 1 hour
+- last 3 hours
+- last 6 hours
+- last 12 hours
+- last 1 day
+- last 3 days
+- last 1 week
+
+The metrics of the stream include (with last 5 minutes as an example), from left to right:
+
+- The **Append records throughout** chart shows the number of records to the stream per second in the last 5 minutes.
+- The **Append bytes throughout** chart shows the number of bytes to the stream per second in the last 5 minutes.
+- The **Total requests** chart shows the number of requests to the stream in the last 5 minutes. Including failed requests.
+- The **Append requests throughout** chart shows the number of requests to the stream per second in the last 5 minutes.
+
+### View stream subscriptions
+
+After clicking the **Subscriptions** tab, you can view the subscriptions of the stream.
+
+To create a new subscription, please refer to [Create a Subscription](./subscription-in-platform.md#create-a-subscription).
+
+For more details about the subscription, please refer to [Subscription Details](./subscription-in-platform.md#subscription-details)
+
+### View stream shards
+
+After clicking the **Shards** tab, you can view the shard details of the stream.
+
+For each shard, you can view the following information:
+
+- The **ID** of the shard.
+- The **Range start** of the shard.
+- The **Range end** of the shard.
+- The current **Status** of the shard.
+
+You can use the ID to get records. Please refer to [Get records in a stream](#get-records-in-a-stream) or [Get Records](./write-in-platform.md#get-records).
+
+### Get records in a stream
+
+After clicking the **Records** tab, you can get records in the stream.
+
+::: tip
+
+To get records from any streams, please refer to [Get Records](./write-in-platform.md#get-records).
+
+:::
+
+You can specify the following filters to get records:
+
+- **Shard**: Select one of the shards in the stream you want to get records from.
+- Special filters:
+  - **Start record ID**: Get records after a specified record ID. The default is the first record.
+  - **Start date**: Get records after a specified date.
+
+After providing the filters (or not), click the **Get records** button to get records. Each record is displayed in a row with the following information:
+
+- The **ID** of the record.
+- The **Key** of the record.
+- The **Value** of the record.
+- The **Shard ID** of the record.
+- The **Creation time** of the record.
+
+## Delete a Stream
+
+This section describes how to delete a stream.
+
+::: warning
+If a stream has subscriptions, this stream cannot be deleted.
+:::
+
+::: danger
+Deleting a stream is irreversible, and the data cannot be recovered after deletion.
+:::
+
+### Delete a stream on the Streams page
+
+1. Navigate to the **Streams** page.
+2. Click the **Delete** icon of the stream you want to delete. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.
+
+### Delete a stream on the Stream Details page
+
+1. Navigate to the details page of the stream you want to delete.
+2. Click the **Delete** button. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.

--- a/docs/zh/platform/subscription-in-platform.md
+++ b/docs/zh/platform/subscription-in-platform.md
@@ -14,7 +14,7 @@ This tutorial guides you on how to create and manage subscriptions in HStream Pl
 
 After clicking the **New subscription** button, you will be directed to the **New subscription** page. You need to set some necessary properties for your stream and create it:
 
-1. Specify the **Subscription ID**. You can refer to [Guidelines to name a resource](../write/stream.md#guidelines-to-name-a-resource) to name a subscription.
+1. Specify the **Subscription ID**. You can refer to [Guidelines to name a resource](../write/stream.md#命名资源准则) to name a subscription.
 
 2. Select a stream as the source from the dropdown list.
 
@@ -25,7 +25,7 @@ After clicking the **New subscription** button, you will be directed to the **Ne
 5. Click the **Confirm** button to create a subscription.
 
 ::: tip
-For more details about **ACK timeout** and **max unacked records**, please refer to [Attributes of a Subscription](../receive/subscription.md#attributes-of-a-subscription).
+For more details about **ACK timeout** and **max unacked records**, please refer to [Attributes of a Subscription](../receive/subscription.md#subscription-的属性).
 :::
 
 ::: warning

--- a/docs/zh/platform/subscription-in-platform.md
+++ b/docs/zh/platform/subscription-in-platform.md
@@ -1,0 +1,117 @@
+# 创建和管理 Subscription
+
+This tutorial guides you on how to create and manage subscriptions in HStream Platform.
+
+## Preparation
+
+1. If you do not have an account, please [apply for a trial](../start/try-out-hstream-platform.md#apply-for-a-trial) first and log in. After logging in, click **Subscriptions** on the left sidebar to enter the subscriptions page.
+
+2. If you have already logged in, click **Subscriptions** on the left sidebar to enter the **Subscriptions** page.
+
+3. Click the **New subscription** button to create a subscription.
+
+## Create a subscription
+
+After clicking the **New subscription** button, you will be directed to the **New subscription** page. You need to set some necessary properties for your stream and create it:
+
+1. Specify the **Subscription ID**. You can refer to [Guidelines to name a resource](../write/stream.md#guidelines-to-name-a-resource) to name a subscription.
+
+2. Select a stream as the source from the dropdown list.
+
+3. Fill in with the **ACK timeout**. The default value is **60**. Unit is **second**.
+
+4. Fill in the number of **max unacked records**. The default value is **100**.
+
+5. Click the **Confirm** button to create a subscription.
+
+::: tip
+For more details about **ACK timeout** and **max unacked records**, please refer to [Attributes of a Subscription](../receive/subscription.md#attributes-of-a-subscription).
+:::
+
+::: warning
+Currently, the number of **ACK timeout** and **max unacked records** are fixed for each subscription in HStream Platform. We will gradually adjust these attributes in the future.
+:::
+
+## View subscriptions
+
+The **Subscriptions** page lists all the subscriptions in your account with a high-level overview. For each subscription, you can view the following information:
+
+- The subscription's **ID**.
+- The name of the **stream** source. You can click on the stream name to navigate the [stream details](./stream-in-platform.md#view-stream-details) page.
+- The **ACK timeout** of the subscription.
+- The **Max unacked records** of the subscription.
+- The **Creation time** of the subscription.
+- **Actions**, which is used to expand the operations of the subscription:
+
+  - **Metrics**: View the metrics of the subscription.
+  - **Consumers**: View the consumers of the subscription.
+  - **Delete**: Delete the subscription.
+
+To view a specific subscription, click the subscription's name. [The details page of the subscription](#view-subscription-details) will be displayed.
+
+## View subscription details
+
+The details page displays detailed information about a subscription:
+
+1. All the information in the [subscriptions](#view-subscriptions) page.
+2. Different tabs are provided to view the related information of the subscription:
+
+   - [**Metrics**](#view-subscription-metrics): View the metrics of the subscription.
+   - [**Consumers**](#view-subscription-consumers): View the consumers of the subscription.
+   - [**Consumption progress**](#view-the-consumption-progress-of-the-subscription): View the consumption progress of the subscription.
+
+### View subscription metrics
+
+After clicking the **Metrics** tab, you can view the metrics of the subscription.
+The default duration is **last 5 minutes**. You can select different durations to control the time range of the metrics:
+
+- last 5 minutes
+- last 1 hour
+- last 3 hours
+- last 6 hours
+- last 12 hours
+- last 1 day
+- last 3 days
+- last 1 week
+
+The metrics of the subscription include (with last 5 minutes as an example), from left to right:
+
+- The **Outcoming bytes throughput** chart shows the number of bytes sent by the subscription per second in the last 5 minutes.
+- The **Outcoming records throughput** chart shows the number of records sent by the subscription per second in the last 5 minutes.
+- The **Acknowledgements throughput** chart shows the number of acknowledgements received in the subscription per second in the last 5 minutes.
+- The **Resent records** chart shows the number of records resent in the subscription in the last 5 minutes.
+
+### View subscription consumers
+
+After clicking the **Consumers** tab, you can view the consumers of the subscription.
+
+For each consumer, you can view the following information:
+
+- The **Name** of the consumer.
+- The **Type** of the consumer.
+- The **URI** of the consumer.
+
+### View the consumption progress of the subscription
+
+After clicking the **Consumption progress** tab, you can view the consumption progress of the subscription.
+
+For each progress, you can view the following information:
+
+- The **Shard ID** of the progress.
+- The **Last checkpoint** of the progress.
+
+## Delete a Subscription
+
+This section describes how to delete a subscription.
+
+### Delete a subscription on the Subscriptions page
+
+1. Go to the **Subscriptions** page.
+2. Click the **Delete** icon of the subscription you want to delete. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.
+
+### Delete a subscription on Subscription Details page
+
+1. Go to the details page of the subscription you want to delete.
+2. Click the **Delete** button. A confirmation dialog will pop up.
+3. Confirm the deletion by clicking the **Confirm** button in the dialog.

--- a/docs/zh/platform/write-in-platform.md
+++ b/docs/zh/platform/write-in-platform.md
@@ -1,0 +1,85 @@
+# 向 Stream 写入 Records
+
+After creating a stream, you can write records to it according to the needs of your application.
+This page describes how to write and get records in HStream Platform.
+
+## Preparation
+
+To write records, you need to create a stream first.
+
+1. If you do not have a stream, please refer to [Create a Stream](./stream-in-platform.md#create-a-stream) to create a stream.
+
+2. Go into any stream you want to write records to on the **Streams** page.
+
+3. Click the **Write records** button to write records to the stream.
+
+## Write records
+
+A record is like a piece of JSON data. You can add arbitrary fields to a record, only ensure that the record is a valid JSON object.
+
+A record also ships with a partition key, which is used to determine which shard the record will be allocated to and improve the read/write performance.
+
+::: tip
+For more details about the partition key, please refer to [Partition Key](../write/write.md#write-records-with-partition-keys).
+:::
+
+Take the following steps to write records to a stream:
+
+1. Specify the optional **Key**. This is the partition key of the record. The server will automatically assign a default key to the record if not provided.
+
+2. Fill in the **Value**. This is the content of the record. It must be a valid JSON object.
+
+3. Click the **Produce** button to write the record to the stream.
+
+4. If the record is written successfully, you will see a success message below the **Produce** button.
+
+5. If the record is written failed, you will see a failure message below the **Produce** button.
+
+## Get Records
+
+After writing records to a stream, you can get records from the **Records** page or the **Stream Details** page.
+
+### Get records from the Records page
+
+After navigating to the **Records** page, you can get records from a stream.
+
+Below are several filters you can use to get records:
+
+- **Stream**: Select the stream you want to get records.
+- **Shard**: Select one of the shards in the stream you want to get records.
+- Special filters:
+  - **Start record ID**: Get records after a specified record ID. The default is the first record.
+  - **Start date**: Get records after a specified date.
+
+::: info
+The **Stream** and **Shard** will be filled automatically after loading the page.
+By default, the filled value is the first stream and the first shard in the stream.
+You can change them to get records from other streams.
+:::
+
+::: info
+We default to showing at most **100 records** after getting. If you want to get more records,
+please specify a recent record ID in the **Start record ID** field or a recent date in the **Start date** field.
+:::
+
+After filling in the filters, click the **Get records** button to get records.
+
+For each record, you can view the following information:
+
+1. The **ID** of the record.
+2. The **Key** of the record.
+3. The **Value** of the record.
+4. The **Shard ID** of the record.
+5. The **Creation time** of the record.
+
+In the next section, you will learn how to get records from the Stream Details page.
+
+### Get records from the Stream Details page
+
+Similar to [Get records from Records page](#get-records-from-the-records-page),
+you can also get records from the **Stream Details** page.
+
+The difference is that you can get records without specifying the stream.
+The records will automatically be retrieved from the stream you are currently viewing.
+
+For more details, please refer to [Get records in a stream](./stream-in-platform.md#get-records-in-a-stream).

--- a/docs/zh/receive/subscription.md
+++ b/docs/zh/receive/subscription.md
@@ -1,6 +1,6 @@
 # 创建和管理 Subscription
 
-Subscription 的属性
+## Subscription 的属性
 
 - ackTimeoutSeconds
 

--- a/docs/zh/start/_index.md
+++ b/docs/zh/start/_index.md
@@ -1,5 +1,7 @@
 ---
-order: ["quickstart-with-docker.md"]
+order:
+  - try-out-hstream-platform.md
+  - quickstart-with-docker.md
 collapsed: false
 ---
 

--- a/docs/zh/start/try-out-hstream-platform.md
+++ b/docs/zh/start/try-out-hstream-platform.md
@@ -16,7 +16,7 @@ If you already have an account, you can skip this step.
 By creating an account, you agree to the [Terms of Service](https://www.emqx.com/en/policy/terms-of-use) and [Privacy Policy](https://www.emqx.com/en/policy/privacy-policy).
 :::
 
-To create a new account, please fill in the required information on the form provided on the [Sign Up](https://platform.hstream.io/app/signup) page, all fields are shown below:
+To create a new account, please fill in the required information on the form provided on the [Sign Up](https://platform.hstream.io/console/signup) page, all fields are shown below:
 
 - **Username**: Your username.
 - **Email**: Your email address. This email address will be used for the HStream Platform login.
@@ -27,7 +27,7 @@ After completing the necessary fields, click the **Sign Up** button to proceed w
 
 ### Log in to the HStream Platform
 
-To log in to the HStream Platform after creating an account, please fill in the required information on the form provided on the [Log In](https://platform.hstream.io/app/login) page, all fields are shown below:
+To log in to the HStream Platform after creating an account, please fill in the required information on the form provided on the [Log In](https://platform.hstream.io/console/login) page, all fields are shown below:
 
 - **Email**: Your email address.
 - **Password**: Your password.

--- a/docs/zh/start/try-out-hstream-platform.md
+++ b/docs/zh/start/try-out-hstream-platform.md
@@ -1,0 +1,85 @@
+# 开始使用 HStream Platform
+
+This page guides you on how to try out the HStream Platform quickly from scratch.
+You will learn how to create a stream, write records to the stream, and query records from the stream.
+
+## Apply for a Trial
+
+Before starting, you need to apply for a trial account for the HStream Platform.
+If you already have an account, you can skip this step.
+
+### Create a new account
+
+<!-- FIXME: update policy links -->
+
+::: info
+By creating an account, you agree to the [Terms of Service](https://www.emqx.com/en/policy/terms-of-use) and [Privacy Policy](https://www.emqx.com/en/policy/privacy-policy).
+:::
+
+To create a new account, please fill in the required information on the form provided on the [Sign Up](https://platform.hstream.io/app/signup) page, all fields are shown below:
+
+- **Username**: Your username.
+- **Email**: Your email address. This email address will be used for the HStream Platform login.
+- **Password**: Your password. The password must be at least eight characters long.
+- **Company (Optional)**: Your company name.
+
+After completing the necessary fields, click the **Sign Up** button to proceed with creating your new account. In case of a successful account creation, you will be redirected to the login page.
+
+### Log in to the HStream Platform
+
+To log in to the HStream Platform after creating an account, please fill in the required information on the form provided on the [Log In](https://platform.hstream.io/app/login) page, all fields are shown below:
+
+- **Email**: Your email address.
+- **Password**: Your password.
+
+Once you have successfully logged in, you will be redirected to the home of HStream Platform.
+
+## Create a stream
+
+To create a new stream, follow the steps below:
+
+1. Head to the **Streams** page and locate the **New stream** button.
+2. Once clicked, you will be directed to the **New stream** page.
+3. Here, simply provide a name for the stream and leave the other fields as default.
+4. Finally, click on the **Create** button to finalize the stream creation process.
+
+The stream will be created immediately, and you will see the stream listed on the **Streams** page.
+
+::: tip
+For more information about how to create a stream, see [Create a Stream](../platform/stream-in-platform.md#create-a-stream).
+:::
+
+## Write records to the stream
+
+After creating a stream, you can write records to the stream. Go to the stream details page by clicking the stream name in the table and
+then click the **Write records** button. A drawer will appear, and you can write records to the stream in the drawer.
+
+In this example, we will write the following record to the stream:
+
+```json
+{ "name": "Alice", "age": 18 }
+```
+
+Please fill it in the **Value** Field and click the **Produce** button.
+
+If the record is written successfully, you will see a success message and the response
+of the request.
+
+Next, we can query this record from the stream.
+
+::: tip
+For more information about how to write records to a stream, see [Write Records to Streams](../platform/write-in-platform.md).
+:::
+
+## Get records from the stream
+
+After writing records to the stream, you can get records from the stream. Go back
+to the stream page, click the **Records** tab, you will see a empty table.
+
+Click the **Get records** button, and then the record written in the previous step will be displayed.
+
+## Next steps
+
+- Explore the [stream in details](../platform/stream-in-platform.md#view-stream-details).
+- [Create a subscription](../platform/subscription-in-platform.md#create-a-subscription) to consume records from the stream.
+- [Query records](../platform/write-in-platform.md#query-records) from streams.


### PR DESCRIPTION
This PR duplicates current platform docs to the `zh` folder, with the title translated.