### PR TITLE
chore: allow to overwrite versioned docs

### DIFF
--- a/.github/workflows/check-out-new-version.yaml
+++ b/.github/workflows/check-out-new-version.yaml
@@ -17,7 +17,7 @@ jobs:
           git push origin release-${{ github.ref_name }}
 
       - name: Check out new version
-        run: ./check-out-version.sh --version ${{ github.ref_name }}
+        run: ./check-out-version.sh --version ${{ github.ref_name }} --force
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5

--- a/check-out-version.sh
+++ b/check-out-version.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 VERSION=""
+FORCE=false
+REMOVE=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -11,12 +13,36 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
+    --force)
+      FORCE=true
+      shift
+      ;;
+    --remove)
+      REMOVE=true
+      shift
+      ;;
   esac
 done
 
 if [[ -z "$VERSION" ]]; then
   echo "You must use --version (such as --version v0.15.0) to provide a version for checkout."
   exit 1
+fi
+
+if [[ "$REMOVE" == "true" ]]; then
+  rm -rf "docs/$VERSION"
+  rm -rf "docs/zh/$VERSION"
+  exit 0
+fi
+
+if [[ -d "docs/$VERSION" ]]; then
+  if [[ "$FORCE" == "true" ]]; then
+    rm -rf "docs/$VERSION"
+    rm -rf "docs/zh/$VERSION"
+  else
+    echo "docs $VERSION already exists. Use --force to overwrite it."
+    exit 1
+  fi
 fi
 
 cp -r docs docs-$VERSION


### PR DESCRIPTION
With this PR, it is now possible to re-tag the same version and overwrite the documentation.